### PR TITLE
Refactor Frontend for ESLint compliance

### DIFF
--- a/frontend/app/athletes/dashboard/page.tsx
+++ b/frontend/app/athletes/dashboard/page.tsx
@@ -78,7 +78,7 @@ export default function AthleteDashboard() {
       socket.off('match', onMatch);
       closeSocket();
     };
-  }, [athleteId, user]);
+  }, [athleteId, user, router]);
 
   useEffect(() => {
     if (!loading) {

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -8,7 +8,7 @@ export default function TermsPage() {
         <h2 className="text-xl font-semibold mb-2">Acceptance of Terms</h2>
         <p>
           By accessing this demo you agree to use it solely for evaluation
-          purposes. The application is provided "as is" with no warranties or
+          purposes. The application is provided &quot;as is&quot; with no warranties or
           guarantees.
         </p>
       </section>

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,8 +1,8 @@
-import axios from 'axios';
+import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
 const useMock = !process.env.NEXT_PUBLIC_API_URL;
 
-let api: any;
+let api: AxiosInstance;
 
 if (useMock) {
   const mockAthletes = [
@@ -60,13 +60,13 @@ if (useMock) {
     post: async () => ({ data: {} }),
     patch: async () => ({ data: {} }),
     put: async () => ({ data: {} }),
-  };
+  } as unknown as AxiosInstance;
 } else {
   api = axios.create({
     baseURL: process.env.NEXT_PUBLIC_API_URL,
   });
 
-  api.interceptors.request.use((config: any) => {
+  api.interceptors.request.use((config: AxiosRequestConfig) => {
     if (typeof window !== 'undefined') {
       const stored = localStorage.getItem('auth');
       if (stored) {


### PR DESCRIPTION
## Summary
- fix Terms page HTML entities
- add router to effect dependencies
- switch API module to typed Axios interface

## Testing
- `npm --workspace frontend run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686150dfe5a483319098dd3ffb552272