### PR TITLE
Add automatic MongoDB seeding

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -8,3 +8,4 @@ JWT_SECRET=your_jwt_secret
 STRIPE_SECRET_KEY=sk_test_your_key
 STRIPE_PRICE_ID=price_test_id
 FRONTEND_URL=http://localhost:3000
+SEED_DB=false

--- a/server/README.md
+++ b/server/README.md
@@ -15,3 +15,13 @@ The server connects to MongoDB using the `MONGO_URI` environment variable. Set `
 ## WebSocket API
 
 Socket.IO is used for real-time chat. Connect to `ws://localhost:3001/socket.io` (replace host and port as needed) and optionally provide `userId` and `roomId` as query parameters. Clients can emit a `join` event with a room id to subscribe and send `message` events with `{ roomId, text, senderId }` to chat. All messages are broadcast to the room and persisted in MongoDB.
+
+## Seeding the Database
+
+Run the seed script after configuring your `.env` file to populate MongoDB with sample data. This creates an athlete, a recruiter and related records.
+
+```bash
+npm run seed
+```
+
+Set the `SEED_DB` environment variable to `true` when starting the server if you want the data seeded automatically on connect.

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
     "dev": "ts-node src/server.ts",
     "build": "tsc",
     "start": "node dist/server.js",
-    "test": "jest --config jest.config.js"
+    "test": "jest --config jest.config.js",
+    "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.531.0",

--- a/server/src/models/User.ts
+++ b/server/src/models/User.ts
@@ -1,0 +1,16 @@
+import mongoose from 'mongoose';
+
+const userSchema = new mongoose.Schema(
+  {
+    name: { type: String, required: true },
+    email: { type: String, required: true, unique: true },
+    passwordHash: { type: String, required: false },
+    role: { type: String, default: 'user' },
+    isVerified: { type: Boolean, default: false },
+    isSubscribed: { type: Boolean, default: false },
+    avatar: String,
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model('User', userSchema);

--- a/server/src/seed.ts
+++ b/server/src/seed.ts
@@ -1,0 +1,71 @@
+import bcrypt from 'bcrypt';
+import User from './models/User';
+import Athlete from './models/Athlete';
+import Recruiter from './models/Recruiter';
+import Match from './models/Match';
+import Message from './models/Message';
+
+export async function seedDatabase(): Promise<void> {
+  const existing = await User.countDocuments();
+  if (existing > 0) {
+    console.log('Database already seeded');
+    return;
+  }
+
+  const passwordHash = await bcrypt.hash('password123', 10);
+  const athleteUser = new User({
+    name: 'Demo Athlete',
+    email: 'athlete@example.com',
+    passwordHash,
+    role: 'athlete',
+    isVerified: true,
+  });
+  const recruiterUser = new User({
+    name: 'Demo Recruiter',
+    email: 'recruiter@example.com',
+    passwordHash,
+    role: 'recruiter',
+    isVerified: true,
+  });
+  await athleteUser.save();
+  await recruiterUser.save();
+
+  const athlete = new Athlete({
+    user: athleteUser._id,
+    sport: 'Soccer',
+    position: 'Forward',
+    bio: 'Demo athlete bio',
+  });
+  const recruiter = new Recruiter({
+    user: recruiterUser._id,
+    company: 'Acme Corp',
+    bio: 'Demo recruiter bio',
+  });
+  await athlete.save();
+  await recruiter.save();
+
+  const match = new Match({ athlete: athlete._id, recruiter: recruiter._id, status: 'accepted' });
+  await match.save();
+
+  const message = new Message({ match: match._id, sender: athleteUser._id, text: 'Welcome to TalentScout!' });
+  await message.save();
+
+  console.log('Seed data created');
+}
+
+if (require.main === module) {
+  // run as standalone script
+  import('dotenv').then(({ default: dotenv }) => {
+    dotenv.config();
+    const mongoose = require('mongoose');
+    const uri = process.env.MONGO_URI || 'mongodb://localhost:27017/talentscout';
+    mongoose
+      .connect(uri)
+      .then(() => seedDatabase())
+      .then(() => mongoose.disconnect())
+      .catch((err: any) => {
+        console.error(err);
+        process.exit(1);
+      });
+  });
+}

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -13,6 +13,8 @@ import Athlete from './models/Athlete';
 import Recruiter from './models/Recruiter';
 import Match from './models/Match';
 import Message from './models/Message';
+import User from './models/User';
+import { seedDatabase } from './seed';
 
 dotenv.config();
 
@@ -30,21 +32,13 @@ const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || '', {
 });
 
 mongoose.connect(MONGO_URI)
-  .then(() => console.log('MongoDB connected'))
+  .then(async () => {
+    console.log('MongoDB connected');
+    if (process.env.SEED_DB === 'true') {
+      await seedDatabase();
+    }
+  })
   .catch((err) => console.error('MongoDB connection error', err));
-
-// User schema
-const userSchema = new mongoose.Schema({
-  name: { type: String, required: true },
-  email: { type: String, required: true, unique: true },
-  passwordHash: { type: String, required: false },
-  role: { type: String, default: 'user' },
-  isVerified: { type: Boolean, default: false },
-  isSubscribed: { type: Boolean, default: false },
-  avatar: String,
-}, { timestamps: true });
-
-export const User = mongoose.model('User', userSchema);
 
 // AWS S3 setup
 const s3 = new S3Client({
@@ -330,3 +324,4 @@ if (process.env.NODE_ENV !== 'test') {
 }
 
 export default app;
+export { User };


### PR DESCRIPTION
## Summary
- factor out User model
- add database seeding script
- seed when `SEED_DB=true` on startup
- document seeding process

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68623e2e732c8331a2161a5050b83fcc